### PR TITLE
Richard

### DIFF
--- a/install_ldsc_cartesius
+++ b/install_ldsc_cartesius
@@ -32,6 +32,8 @@ module load python
 cd $HOME
 
 # install packages from your library (in this case, only bitarray is there)
+##Richard: Gives error if not executed in the same folder as install dependencies. Therefore might need #cd ./pythonpackages/bitarray-0.8.1/
+#cd ./pythonpackages/bitarray-0.8.1/
 python setup.py install --home=$HOME/pythonpackages
 
 # check if package is installed -- no error message should pop up. If you get no response from <import bitarray>, 


### PR DESCRIPTION
I had a problem with line 37 since line 32 changes to $HOME and on line 37 we are calling setup.py which is not in my home directory/nor the pythonpackages directory, since the untar creates a new folder, and the path is therefore $HOME/pythonpackages/bitarray-0.8.1/ ?